### PR TITLE
Add prompt editing modal

### DIFF
--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -90,6 +90,30 @@ def save_shot_notes():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
+@shot_bp.route("/prompt", methods=["POST"])
+def save_shot_prompt():
+    try:
+        data = request.get_json()
+        shot_name = data.get("shot_name")
+        asset_type = data.get("asset_type")
+        version = data.get("version")
+        prompt = data.get("prompt", "")
+
+        if not shot_name or not asset_type or version is None:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        shot_manager.save_prompt(shot_name, asset_type, int(version), prompt)
+
+        return jsonify({"success": True})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @shot_bp.route("/rename", methods=["POST"])
 def rename_shot():
     try:

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -241,12 +241,16 @@ class ShotManager:
             except Exception:
                 pass
 
+
         # Latest image
         latest_image, image_version = self._get_latest_asset(
             self.latest_images_dir, shot_dir / 'images',
             shot_name, ALLOWED_IMAGE_EXTENSIONS
         )
         latest_image = str(Path(latest_image).resolve()) if latest_image else None
+        image_prompt = ''
+        if image_version > 0:
+            image_prompt = self.load_prompt(shot_name, 'image', image_version)
 
         # Latest video
         latest_video, video_version = self._get_latest_asset(
@@ -254,6 +258,9 @@ class ShotManager:
             shot_name, ALLOWED_VIDEO_EXTENSIONS
         )
         latest_video = str(Path(latest_video).resolve()) if latest_video else None
+        video_prompt = ''
+        if video_version > 0:
+            video_prompt = self.load_prompt(shot_name, 'video', video_version)
 
         # Lipsync videos
         lipsync_dir = shot_dir / 'lipsync'
@@ -264,10 +271,14 @@ class ShotManager:
                 f'{shot_name}_{part}', ALLOWED_VIDEO_EXTENSIONS
             )
             file_path = str(Path(file_path).resolve()) if file_path else None
+            prompt_text = ''
+            if ver > 0:
+                prompt_text = self.load_prompt(shot_name, part, ver)
             lipsync[part] = {
                 'file': file_path,
                 'version': ver,
-                'thumbnail': None  # will be replaced with image thumb below
+                'thumbnail': None,  # will be replaced with image thumb below
+                'prompt': prompt_text,
             }
 
         # Thumbnails
@@ -288,12 +299,14 @@ class ShotManager:
             'image': {
                 'file': latest_image,
                 'version': image_version,
-                'thumbnail': image_thumb
+                'thumbnail': image_thumb,
+                'prompt': image_prompt,
             },
             'video': {
                 'file': latest_video,
                 'version': video_version,
-                'thumbnail': video_thumb
+                'thumbnail': video_thumb,
+                'prompt': video_prompt,
             },
             'lipsync': lipsync,
             'archived': False  # TODO: Implement archiving
@@ -342,6 +355,43 @@ class ShotManager:
                 f.write(notes)
         except Exception as e:
             raise ValueError(f"Failed to save notes: {str(e)}")
+
+    def _prompt_file_path(self, shot_name, asset_type, version):
+        """Return the path to the prompt file for a specific asset version."""
+        shot_dir = self.wip_dir / shot_name
+        if asset_type == 'image':
+            base_dir = shot_dir / 'images'
+            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+        elif asset_type == 'video':
+            base_dir = shot_dir / 'videos'
+            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+        elif asset_type in {'driver', 'target', 'result'}:
+            base_dir = shot_dir / 'lipsync'
+            filename = f'{shot_name}_{asset_type}_v{version:03d}_prompt.txt'
+        else:
+            raise ValueError('Invalid asset type')
+        return base_dir / filename
+
+    def load_prompt(self, shot_name, asset_type, version):
+        path = self._prompt_file_path(shot_name, asset_type, version)
+        if path.exists():
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    return f.read().strip()
+            except Exception:
+                return ''
+        return ''
+
+    def save_prompt(self, shot_name, asset_type, version, prompt):
+        """Save prompt for a specific asset version."""
+        validate_shot_name(shot_name)
+        path = self._prompt_file_path(shot_name, asset_type, version)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(prompt)
+        except Exception as e:
+            raise ValueError(f"Failed to save prompt: {str(e)}")
 
     def get_thumbnail_path(self, image_path, shot_name):
         """Return (and create if necessary) the thumbnail for an image."""

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -320,6 +320,23 @@
             font-weight: 500;
         }
 
+        .prompt-button {
+            position: absolute;
+            bottom: 4px;
+            right: 4px;
+            background: #3a3a3a;
+            color: #e5e5e5;
+            border: none;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 11px;
+            cursor: pointer;
+        }
+
+        .prompt-button:hover {
+            background: #505050;
+        }
+
         /* Notifications */
         .notification {
             position: fixed;
@@ -506,6 +523,32 @@
             border: 1px solid #444;
             background: transparent;
             color: #eee;
+        }
+
+        .prompt-textarea {
+            width: 100%;
+            height: 200px;
+            background: #2a2a2a;
+            border: 1px solid #404040;
+            border-radius: 6px;
+            padding: 12px;
+            color: #e5e5e5;
+            resize: vertical;
+            font-family: inherit;
+            font-size: 14px;
+            margin-top: 10px;
+            margin-bottom: 20px;
+        }
+
+        .close-modal {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: transparent;
+            color: #e5e5e5;
+            border: none;
+            font-size: 18px;
+            cursor: pointer;
         }
 
         .modal-buttons {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,6 +74,18 @@
         </div>
     </div>
 
+    <!-- Prompt Modal -->
+    <div id="prompt-modal" class="modal" data-shot="">
+        <div class="modal-content" style="position: relative;">
+            <button class="close-modal" onclick="closePromptModal()">&times;</button>
+            <h3 id="prompt-modal-title" style="margin-bottom: 10px;">Prompt</h3>
+            <textarea id="prompt-text" class="prompt-textarea"></textarea>
+            <div class="modal-buttons">
+                <button class="dark-button" onclick="savePrompt()">Save &amp; Close</button>
+            </div>
+        </div>
+    </div>
+
     <footer class='app-footer'>
         Created by <a href="https://albertbozesan.com/">Albert Bozesan</a> with ChatGPT Codex
     </footer>


### PR DESCRIPTION
## Summary
- support storing prompts in backend
- API endpoint to save prompts
- add prompt button on thumbnails
- create prompt editing modal
- style prompt elements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883ad063e00832cb63ce2f12e7167b4