### PR TITLE
Update prompt modal title and file naming

### DIFF
--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -361,10 +361,10 @@ class ShotManager:
         shot_dir = self.wip_dir / shot_name
         if asset_type == 'image':
             base_dir = shot_dir / 'images'
-            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+            filename = f'{shot_name}_v{version:03d}_image_prompt.txt'
         elif asset_type == 'video':
             base_dir = shot_dir / 'videos'
-            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+            filename = f'{shot_name}_v{version:03d}_video_prompt.txt'
         elif asset_type in {'driver', 'target', 'result'}:
             base_dir = shot_dir / 'lipsync'
             filename = f'{shot_name}_{asset_type}_v{version:03d}_prompt.txt'

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -514,6 +514,10 @@
             box-shadow: 0 2px 20px rgba(0,0,0,0.3);
         }
 
+        #prompt-modal .modal-content {
+            width: 800px;
+        }
+
         .modal-content input {
             width: 100%;
             padding: 10px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -613,7 +613,10 @@ function openPromptModal(shotName, assetType, version) {
             prompt = shot.lipsync[assetType].prompt || '';
         }
     }
-    document.getElementById('prompt-modal-title').textContent = `${shotName} Prompt`;
+    const typeLabel = assetType.charAt(0).toUpperCase() + assetType.slice(1);
+    const ver = version.toString().padStart(3, '0');
+    document.getElementById('prompt-modal-title').textContent =
+        `${shotName}_v${ver} ${typeLabel} Prompt`;
     document.getElementById('prompt-text').value = prompt;
     const modal = document.getElementById('prompt-modal');
     modal.dataset.shot = shotName;


### PR DESCRIPTION
## Summary
- widen prompt modal to improve readability
- include asset type and version in prompt modal title
- store prompts with asset type in filename

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883b1ac4c70832c8eacaaeeb5df2b7f