### PR TITLE
Fix prompt modal button issue

### DIFF
--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -137,6 +137,7 @@ def get_shot_prompt():
         return jsonify({"success": False, "error": str(e)}), 500
 
 @shot_bp.route("/prompt_versions")
+@shot_bp.route("/prompt-versions")
 def get_prompt_versions():
     try:
         shot_name = request.args.get("shot_name")

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -94,8 +94,21 @@
     
         // Initialize app
         document.addEventListener('DOMContentLoaded', function() {
+            document.addEventListener('click', handlePromptButtonClick);
             checkForProject();
         });
+
+        function handlePromptButtonClick(event) {
+            const btn = event.target.closest('.prompt-button');
+            if (!btn) {
+                return;
+            }
+            event.stopPropagation();
+            const shot = btn.dataset.shot;
+            const type = btn.dataset.type;
+            const version = parseInt(btn.dataset.version, 10);
+            openPromptModal(shot, type, version);
+        }
 
         async function checkForProject() {
             try {
@@ -262,7 +275,11 @@
                                 onclick="revealFile('${file.file}')"></div>
 
                             <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
-                            <button class="prompt-button" title="View and edit prompt" onclick="openPromptModal('${shot.name}', '${type}', ${file.version})">P</button>
+                            <button class="prompt-button"
+                                    title="View and edit prompt"
+                                    data-shot="${shot.name}"
+                                    data-type="${type}"
+                                    data-version="${file.version}">P</button>
                         </div>
                     </div>
                 `;
@@ -298,7 +315,10 @@
                             <div class="file-preview lipsync-preview">
                                 <div class="preview-thumbnail lipsync-thumbnail" data-label="${label}" style="${thumbnailStyle}" onclick="revealFile('${file.file}')"></div>
                                 <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
-                                <button class="prompt-button" title="View and edit prompt" onclick="openPromptModal('${shot.name}', '${part}', ${file.version})">P</button>
+                                <button class="prompt-button" title="View and edit prompt"
+                                        data-shot="${shot.name}"
+                                        data-type="${part}"
+                                        data-version="${file.version}">P</button>
                             </div>
                         </div>`;
                 } else {


### PR DESCRIPTION
## Summary
- fix prompt button click handler by switching to delegated listener
- attach dataset attributes on generated buttons
- ensure modal opens reliably when clicking P
- add alias route for prompt version lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884a0ef510c832ca5d3751fe60f14f0