### PR TITLE
Update prompt modal logic and button styles

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -579,10 +579,11 @@
             gap: 10px;
         }
 
+
         .green-button {
             padding: 10px 20px;
             background: #00c851;
-            color: #fff;
+            color: #1a1a1a;
             border: none;
             border-radius: 6px;
             font-weight: 600;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,7 +41,7 @@
     <div id="main-interface" style="display: none;">
         <div class="header">
             <h1 class="project-title" id="project-title">Loading...</h1>
-            <button class="new-shot-btn" onclick="addNewShot()">New Shot +</button>
+            <button class="green-button new-shot-btn" onclick="addNewShot()">New Shot +</button>
         </div>
 
         <div class="container">
@@ -88,8 +88,8 @@
             <textarea id="prompt-text" class="prompt-textarea"></textarea>
             <div class="prompt-footer">
                 <div class="left-buttons">
-                    <button class="green-button" onclick="copyToNewPromptVersion()">Copy to new version</button>
-                    <button class="gray-button" onclick="createEmptyPromptVersion()">Create new empty prompt</button>
+                    <button id="copy-prompt-btn" class="green-button" onclick="copyToNewPromptVersion()">Copy to new version</button>
+                    <button id="create-empty-btn" class="dark-button" onclick="createEmptyPromptVersion()">Create new empty prompt</button>
                 </div>
                 <div class="modal-buttons">
                     <button class="dark-button" onclick="savePrompt()">Save &amp; Close</button>


### PR DESCRIPTION
## Summary
- tweak prompt modal to only copy from previous version when no prompt exists
- prevent creating prompt versions beyond latest asset version
- list all version numbers in dropdown
- style buttons consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a7f8bf0c832c91f79b2bcf2aab03