### PR TITLE
Added Prompt Saving & Versioning

### DIFF
--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -137,6 +137,7 @@ def get_shot_prompt():
         return jsonify({"success": False, "error": str(e)}), 500
 
 @shot_bp.route("/prompt_versions")
+@shot_bp.route("/prompt-versions")
 def get_prompt_versions():
     try:
         shot_name = request.args.get("shot_name")

--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -90,6 +90,30 @@ def save_shot_notes():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
+@shot_bp.route("/prompt", methods=["POST"])
+def save_shot_prompt():
+    try:
+        data = request.get_json()
+        shot_name = data.get("shot_name")
+        asset_type = data.get("asset_type")
+        version = data.get("version")
+        prompt = data.get("prompt", "")
+
+        if not shot_name or not asset_type or version is None:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        shot_manager.save_prompt(shot_name, asset_type, int(version), prompt)
+
+        return jsonify({"success": True})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @shot_bp.route("/rename", methods=["POST"])
 def rename_shot():
     try:

--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -114,6 +114,47 @@ def save_shot_prompt():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
+@shot_bp.route("/prompt", methods=["GET"])
+def get_shot_prompt():
+    try:
+        shot_name = request.args.get("shot_name")
+        asset_type = request.args.get("asset_type")
+        version = request.args.get("version", type=int)
+
+        if not shot_name or not asset_type or version is None:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        prompt = shot_manager.load_prompt(shot_name, asset_type, version)
+
+        return jsonify({"success": True, "data": prompt})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+@shot_bp.route("/prompt_versions")
+def get_prompt_versions():
+    try:
+        shot_name = request.args.get("shot_name")
+        asset_type = request.args.get("asset_type")
+        if not shot_name or not asset_type:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        versions = shot_manager.get_prompt_versions(shot_name, asset_type)
+        return jsonify({"success": True, "data": versions})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @shot_bp.route("/rename", methods=["POST"])
 def rename_shot():
     try:

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -241,12 +241,16 @@ class ShotManager:
             except Exception:
                 pass
 
+
         # Latest image
         latest_image, image_version = self._get_latest_asset(
             self.latest_images_dir, shot_dir / 'images',
             shot_name, ALLOWED_IMAGE_EXTENSIONS
         )
         latest_image = str(Path(latest_image).resolve()) if latest_image else None
+        image_prompt = ''
+        if image_version > 0:
+            image_prompt = self.load_prompt(shot_name, 'image', image_version)
 
         # Latest video
         latest_video, video_version = self._get_latest_asset(
@@ -254,6 +258,9 @@ class ShotManager:
             shot_name, ALLOWED_VIDEO_EXTENSIONS
         )
         latest_video = str(Path(latest_video).resolve()) if latest_video else None
+        video_prompt = ''
+        if video_version > 0:
+            video_prompt = self.load_prompt(shot_name, 'video', video_version)
 
         # Lipsync videos
         lipsync_dir = shot_dir / 'lipsync'
@@ -264,10 +271,14 @@ class ShotManager:
                 f'{shot_name}_{part}', ALLOWED_VIDEO_EXTENSIONS
             )
             file_path = str(Path(file_path).resolve()) if file_path else None
+            prompt_text = ''
+            if ver > 0:
+                prompt_text = self.load_prompt(shot_name, part, ver)
             lipsync[part] = {
                 'file': file_path,
                 'version': ver,
-                'thumbnail': None  # will be replaced with image thumb below
+                'thumbnail': None,  # will be replaced with image thumb below
+                'prompt': prompt_text,
             }
 
         # Thumbnails
@@ -288,12 +299,14 @@ class ShotManager:
             'image': {
                 'file': latest_image,
                 'version': image_version,
-                'thumbnail': image_thumb
+                'thumbnail': image_thumb,
+                'prompt': image_prompt,
             },
             'video': {
                 'file': latest_video,
                 'version': video_version,
-                'thumbnail': video_thumb
+                'thumbnail': video_thumb,
+                'prompt': video_prompt,
             },
             'lipsync': lipsync,
             'archived': False  # TODO: Implement archiving
@@ -342,6 +355,43 @@ class ShotManager:
                 f.write(notes)
         except Exception as e:
             raise ValueError(f"Failed to save notes: {str(e)}")
+
+    def _prompt_file_path(self, shot_name, asset_type, version):
+        """Return the path to the prompt file for a specific asset version."""
+        shot_dir = self.wip_dir / shot_name
+        if asset_type == 'image':
+            base_dir = shot_dir / 'images'
+            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+        elif asset_type == 'video':
+            base_dir = shot_dir / 'videos'
+            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+        elif asset_type in {'driver', 'target', 'result'}:
+            base_dir = shot_dir / 'lipsync'
+            filename = f'{shot_name}_{asset_type}_v{version:03d}_prompt.txt'
+        else:
+            raise ValueError('Invalid asset type')
+        return base_dir / filename
+
+    def load_prompt(self, shot_name, asset_type, version):
+        path = self._prompt_file_path(shot_name, asset_type, version)
+        if path.exists():
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    return f.read().strip()
+            except Exception:
+                return ''
+        return ''
+
+    def save_prompt(self, shot_name, asset_type, version, prompt):
+        """Save prompt for a specific asset version."""
+        validate_shot_name(shot_name)
+        path = self._prompt_file_path(shot_name, asset_type, version)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(prompt)
+        except Exception as e:
+            raise ValueError(f"Failed to save prompt: {str(e)}")
 
     def get_thumbnail_path(self, image_path, shot_name):
         """Return (and create if necessary) the thumbnail for an image."""

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -361,10 +361,10 @@ class ShotManager:
         shot_dir = self.wip_dir / shot_name
         if asset_type == 'image':
             base_dir = shot_dir / 'images'
-            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+            filename = f'{shot_name}_v{version:03d}_image_prompt.txt'
         elif asset_type == 'video':
             base_dir = shot_dir / 'videos'
-            filename = f'{shot_name}_v{version:03d}_prompt.txt'
+            filename = f'{shot_name}_v{version:03d}_video_prompt.txt'
         elif asset_type in {'driver', 'target', 'result'}:
             base_dir = shot_dir / 'lipsync'
             filename = f'{shot_name}_{asset_type}_v{version:03d}_prompt.txt'

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -393,6 +393,35 @@ class ShotManager:
         except Exception as e:
             raise ValueError(f"Failed to save prompt: {str(e)}")
 
+    def get_prompt_versions(self, shot_name, asset_type):
+        """Return a sorted list of prompt versions for the given asset."""
+        shot_dir = self.wip_dir / shot_name
+        if asset_type == 'image':
+            base_dir = shot_dir / 'images'
+            pattern = f'{shot_name}_v*_image_prompt.txt'
+        elif asset_type == 'video':
+            base_dir = shot_dir / 'videos'
+            pattern = f'{shot_name}_v*_video_prompt.txt'
+        elif asset_type in {'driver', 'target', 'result'}:
+            base_dir = shot_dir / 'lipsync'
+            pattern = f'{shot_name}_{asset_type}_v*_prompt.txt'
+        else:
+            raise ValueError('Invalid asset type')
+
+        versions = []
+        if base_dir.exists():
+            for f in base_dir.glob(pattern):
+                stem = f.stem
+                if '_v' not in stem:
+                    continue
+                try:
+                    part = stem.split('_v')[1]
+                    ver_str = part.split('_')[0]
+                    versions.append(int(ver_str))
+                except (IndexError, ValueError):
+                    continue
+        return sorted(set(versions))
+
     def get_thumbnail_path(self, image_path, shot_name):
         """Return (and create if necessary) the thumbnail for an image."""
         if not image_path:

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -320,6 +320,23 @@
             font-weight: 500;
         }
 
+        .prompt-button {
+            position: absolute;
+            bottom: 4px;
+            right: 4px;
+            background: #3a3a3a;
+            color: #e5e5e5;
+            border: none;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 11px;
+            cursor: pointer;
+        }
+
+        .prompt-button:hover {
+            background: #505050;
+        }
+
         /* Notifications */
         .notification {
             position: fixed;
@@ -506,6 +523,32 @@
             border: 1px solid #444;
             background: transparent;
             color: #eee;
+        }
+
+        .prompt-textarea {
+            width: 100%;
+            height: 200px;
+            background: #2a2a2a;
+            border: 1px solid #404040;
+            border-radius: 6px;
+            padding: 12px;
+            color: #e5e5e5;
+            resize: vertical;
+            font-family: inherit;
+            font-size: 14px;
+            margin-top: 10px;
+            margin-bottom: 20px;
+        }
+
+        .close-modal {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: transparent;
+            color: #e5e5e5;
+            border: none;
+            font-size: 18px;
+            cursor: pointer;
         }
 
         .modal-buttons {

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -518,6 +518,97 @@
             width: 800px;
         }
 
+        #prompt-modal-title {
+            margin-bottom: 10px;
+            text-align: left;
+        }
+
+        .prompt-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+
+        .version-select {
+            position: relative;
+        }
+
+        .pill-button {
+            padding: 5px 12px;
+            background: #3a3a3a;
+            color: #e5e5e5;
+            border: none;
+            border-radius: 999px;
+            cursor: pointer;
+        }
+
+        .dropdown-menu {
+            display: none;
+            position: absolute;
+            top: 110%;
+            left: 0;
+            background: #252525;
+            border: 1px solid #444;
+            border-radius: 6px;
+            min-width: 80px;
+            z-index: 100;
+        }
+
+        .dropdown-menu.show {
+            display: block;
+        }
+
+        .dropdown-item {
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+
+        .dropdown-item:hover {
+            background: #3a3a3a;
+        }
+
+        .prompt-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .left-buttons {
+            display: flex;
+            gap: 10px;
+        }
+
+        .green-button {
+            padding: 10px 20px;
+            background: #00c851;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .green-button:hover {
+            background: #00a143;
+        }
+
+        .gray-button {
+            padding: 10px 20px;
+            background: #555;
+            color: #e5e5e5;
+            border: none;
+            border-radius: 6px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .gray-button:hover {
+            background: #6b6b6b;
+        }
+
         .modal-content input {
             width: 100%;
             padding: 10px;

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -514,6 +514,10 @@
             box-shadow: 0 2px 20px rgba(0,0,0,0.3);
         }
 
+        #prompt-modal .modal-content {
+            width: 800px;
+        }
+
         .modal-content input {
             width: 100%;
             padding: 10px;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -603,31 +603,155 @@ async function revealFile(relPath) {
     }
 }
 
-function openPromptModal(shotName, assetType, version) {
-    const shot = shots.find(s => s.name === shotName);
-    let prompt = '';
-    if (shot) {
-        if (assetType === 'image' || assetType === 'video') {
-            prompt = shot[assetType].prompt || '';
-        } else if (shot.lipsync && shot.lipsync[assetType]) {
-            prompt = shot.lipsync[assetType].prompt || '';
+async function fetchPrompt(shotName, assetType, version) {
+    try {
+        const resp = await fetch(`/api/shots/prompt?shot_name=${encodeURIComponent(shotName)}&asset_type=${assetType}&version=${version}`);
+        const data = await resp.json();
+        if (data.success) {
+            return data.data || '';
         }
+    } catch (e) {
+        console.error('Failed to load prompt:', e);
     }
-    const typeLabel = assetType.charAt(0).toUpperCase() + assetType.slice(1);
-    const ver = version.toString().padStart(3, '0');
-    document.getElementById('prompt-modal-title').textContent =
-        `${shotName}_v${ver} ${typeLabel} Prompt`;
+    return '';
+}
+
+async function fetchPromptVersions(shotName, assetType) {
+    try {
+        const resp = await fetch(`/api/shots/prompt_versions?shot_name=${encodeURIComponent(shotName)}&asset_type=${assetType}`);
+        const data = await resp.json();
+        if (data.success) {
+            return data.data || [];
+        }
+    } catch (e) {
+        console.error('Failed to load prompt versions:', e);
+    }
+    return [];
+}
+
+function buildVersionDropdown(versions, currentVersion) {
+    const btn = document.getElementById('version-dropdown-btn');
+    const menu = document.getElementById('version-dropdown-menu');
+    menu.innerHTML = '';
+    versions.sort((a, b) => a - b);
+    versions.forEach(v => {
+        const item = document.createElement('div');
+        item.className = 'dropdown-item';
+        item.dataset.version = v;
+        item.textContent = `v${String(v).padStart(3, '0')}`;
+        item.onclick = () => selectPromptVersion(v);
+        menu.appendChild(item);
+    });
+    btn.textContent = `v${String(currentVersion).padStart(3, '0')} \u25BE`;
+}
+
+function toggleVersionDropdown() {
+    const menu = document.getElementById('version-dropdown-menu');
+    menu.classList.toggle('show');
+}
+
+async function selectPromptVersion(v) {
+    const modal = document.getElementById('prompt-modal');
+    const shotName = modal.dataset.shot;
+    const assetType = modal.dataset.type;
+    modal.dataset.version = v;
+    const versions = JSON.parse(modal.dataset.versions || '[]');
+    buildVersionDropdown(versions, v);
+    const prompt = await fetchPrompt(shotName, assetType, v);
     document.getElementById('prompt-text').value = prompt;
+    toggleVersionDropdown();
+}
+
+async function openPromptModal(shotName, assetType, version) {
     const modal = document.getElementById('prompt-modal');
     modal.dataset.shot = shotName;
     modal.dataset.type = assetType;
+
+    const typeLabel = assetType.charAt(0).toUpperCase() + assetType.slice(1);
+    document.getElementById('prompt-modal-title').textContent = `${shotName} ${typeLabel} Prompt`;
+
+    let versions = await fetchPromptVersions(shotName, assetType);
+    const isNew = !versions.includes(version);
+    if (isNew) {
+        versions.push(version);
+    }
+    modal.dataset.versions = JSON.stringify(versions);
+    buildVersionDropdown(versions, version);
+
+    let prompt = await fetchPrompt(shotName, assetType, version);
+    if (isNew && versions.length > 1) {
+        const sorted = [...versions].sort((a,b)=>a-b);
+        const idx = sorted.indexOf(version);
+        const prev = sorted[idx - 1];
+        if (prev !== undefined) {
+            prompt = await fetchPrompt(shotName, assetType, prev);
+        }
+    }
     modal.dataset.version = version;
+    document.getElementById('prompt-text').value = prompt;
+
     modal.style.display = 'flex';
     document.getElementById('prompt-text').focus();
 }
 
 function closePromptModal() {
     document.getElementById('prompt-modal').style.display = 'none';
+}
+
+async function copyToNewPromptVersion() {
+    const modal = document.getElementById('prompt-modal');
+    const shotName = modal.dataset.shot;
+    const assetType = modal.dataset.type;
+    let versions = JSON.parse(modal.dataset.versions || '[]');
+    const nextVersion = versions.length ? Math.max(...versions) + 1 : 1;
+    const currentPrompt = document.getElementById('prompt-text').value;
+    try {
+        const resp = await fetch('/api/shots/prompt', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ shot_name: shotName, asset_type: assetType, version: nextVersion, prompt: currentPrompt })
+        });
+        const result = await resp.json();
+        if (!result.success) {
+            showNotification(result.error || 'Failed to save prompt', 'error');
+            return;
+        }
+        versions.push(nextVersion);
+        modal.dataset.versions = JSON.stringify(versions);
+        modal.dataset.version = nextVersion;
+        buildVersionDropdown(versions, nextVersion);
+    } catch (e) {
+        console.error('Failed to copy prompt:', e);
+        showNotification('Failed to save prompt', 'error');
+    }
+}
+
+async function createEmptyPromptVersion() {
+    const modal = document.getElementById('prompt-modal');
+    const shotName = modal.dataset.shot;
+    const assetType = modal.dataset.type;
+    let versions = JSON.parse(modal.dataset.versions || '[]');
+    const nextVersion = versions.length ? Math.max(...versions) + 1 : 1;
+    try {
+        const resp = await fetch('/api/shots/prompt', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ shot_name: shotName, asset_type: assetType, version: nextVersion, prompt: '' })
+        });
+        const result = await resp.json();
+        if (!result.success) {
+            showNotification(result.error || 'Failed to save prompt', 'error');
+            return;
+        }
+        versions.push(nextVersion);
+        modal.dataset.versions = JSON.stringify(versions);
+        modal.dataset.version = nextVersion;
+        buildVersionDropdown(versions, nextVersion);
+        document.getElementById('prompt-text').value = '';
+    } catch (e) {
+        console.error('Failed to create prompt:', e);
+        showNotification('Failed to save prompt', 'error');
+    }
 }
 
 async function savePrompt() {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -613,7 +613,10 @@ function openPromptModal(shotName, assetType, version) {
             prompt = shot.lipsync[assetType].prompt || '';
         }
     }
-    document.getElementById('prompt-modal-title').textContent = `${shotName} Prompt`;
+    const typeLabel = assetType.charAt(0).toUpperCase() + assetType.slice(1);
+    const ver = version.toString().padStart(3, '0');
+    document.getElementById('prompt-modal-title').textContent =
+        `${shotName}_v${ver} ${typeLabel} Prompt`;
     document.getElementById('prompt-text').value = prompt;
     const modal = document.getElementById('prompt-modal');
     modal.dataset.shot = shotName;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -94,8 +94,21 @@
     
         // Initialize app
         document.addEventListener('DOMContentLoaded', function() {
+            document.addEventListener('click', handlePromptButtonClick);
             checkForProject();
         });
+
+        function handlePromptButtonClick(event) {
+            const btn = event.target.closest('.prompt-button');
+            if (!btn) {
+                return;
+            }
+            event.stopPropagation();
+            const shot = btn.dataset.shot;
+            const type = btn.dataset.type;
+            const version = parseInt(btn.dataset.version, 10);
+            openPromptModal(shot, type, version);
+        }
 
         async function checkForProject() {
             try {
@@ -262,7 +275,11 @@
                                 onclick="revealFile('${file.file}')"></div>
 
                             <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
-                            <button class="prompt-button" title="View and edit prompt" onclick="openPromptModal('${shot.name}', '${type}', ${file.version})">P</button>
+                            <button class="prompt-button"
+                                    title="View and edit prompt"
+                                    data-shot="${shot.name}"
+                                    data-type="${type}"
+                                    data-version="${file.version}">P</button>
                         </div>
                     </div>
                 `;
@@ -298,7 +315,10 @@
                             <div class="file-preview lipsync-preview">
                                 <div class="preview-thumbnail lipsync-thumbnail" data-label="${label}" style="${thumbnailStyle}" onclick="revealFile('${file.file}')"></div>
                                 <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
-                                <button class="prompt-button" title="View and edit prompt" onclick="openPromptModal('${shot.name}', '${part}', ${file.version})">P</button>
+                                <button class="prompt-button" title="View and edit prompt"
+                                        data-shot="${shot.name}"
+                                        data-type="${part}"
+                                        data-version="${file.version}">P</button>
                             </div>
                         </div>`;
                 } else {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,6 +74,18 @@
         </div>
     </div>
 
+    <!-- Prompt Modal -->
+    <div id="prompt-modal" class="modal" data-shot="">
+        <div class="modal-content" style="position: relative;">
+            <button class="close-modal" onclick="closePromptModal()">&times;</button>
+            <h3 id="prompt-modal-title" style="margin-bottom: 10px;">Prompt</h3>
+            <textarea id="prompt-text" class="prompt-textarea"></textarea>
+            <div class="modal-buttons">
+                <button class="dark-button" onclick="savePrompt()">Save &amp; Close</button>
+            </div>
+        </div>
+    </div>
+
     <footer class='app-footer'>
         Created by <a href="https://albertbozesan.com/">Albert Bozesan</a> with ChatGPT Codex
     </footer>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -75,13 +75,25 @@
     </div>
 
     <!-- Prompt Modal -->
-    <div id="prompt-modal" class="modal" data-shot="">
-        <div class="modal-content" style="position: relative;">
+        <div id="prompt-modal" class="modal" data-shot="">
+        <div class="modal-content prompt-modal-content" style="position: relative;">
             <button class="close-modal" onclick="closePromptModal()">&times;</button>
-            <h3 id="prompt-modal-title" style="margin-bottom: 10px;">Prompt</h3>
+            <div class="prompt-header">
+                <h3 id="prompt-modal-title">Prompt</h3>
+                <div class="version-select">
+                    <button id="version-dropdown-btn" class="pill-button" onclick="toggleVersionDropdown()">v001 &#9662;</button>
+                    <div id="version-dropdown-menu" class="dropdown-menu"></div>
+                </div>
+            </div>
             <textarea id="prompt-text" class="prompt-textarea"></textarea>
-            <div class="modal-buttons">
-                <button class="dark-button" onclick="savePrompt()">Save &amp; Close</button>
+            <div class="prompt-footer">
+                <div class="left-buttons">
+                    <button class="green-button" onclick="copyToNewPromptVersion()">Copy to new version</button>
+                    <button class="gray-button" onclick="createEmptyPromptVersion()">Create new empty prompt</button>
+                </div>
+                <div class="modal-buttons">
+                    <button class="dark-button" onclick="savePrompt()">Save &amp; Close</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Prompts can now be saved via the "P" button on each asset thumbnail. This opens a popup window which allows users to save their prompt as plain text. The popup also includes a pill button dropdown to view previous promp versions. By default, when a new asset version is added, a "Copy prompt from previous version" button will allow copying the previous version's prompt to the new version.

In the file system, prompts are saved as .txt files in the wip folder with all asset versions.