### PR TITLE
Ensure notification slides completely out

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -347,7 +347,8 @@
             padding: 12px 16px;
             border-radius: 8px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.4);
-            transform: translateX(400px);
+            /* Move the notification completely off screen */
+            transform: translateX(calc(100% + 40px));
             transition: transform 0.3s ease;
             z-index: 1000;
             font-weight: 500;


### PR DESCRIPTION
## Summary
- tweak notification slide-out animation so long messages fully disappear

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b2b7ceb8832caf5941446bc99838