### PR TITLE
Add asset version dropdown

### DIFF
--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -156,6 +156,51 @@ def get_prompt_versions():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
+
+@shot_bp.route("/asset-versions")
+def get_asset_versions():
+    try:
+        shot_name = request.args.get("shot_name")
+        asset_type = request.args.get("asset_type")
+        if not shot_name or not asset_type:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        versions = shot_manager.get_asset_versions(shot_name, asset_type)
+        return jsonify({"success": True, "data": versions})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@shot_bp.route("/set-latest", methods=["POST"])
+def set_latest_version():
+    try:
+        data = request.get_json()
+        shot_name = data.get("shot_name")
+        asset_type = data.get("asset_type")
+        version = data.get("version")
+        if not shot_name or not asset_type or version is None:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        file_handler = FileHandler(project["path"])
+        result = file_handler.set_latest_version(shot_name, asset_type, int(version))
+
+        return jsonify({"success": True, "data": result})
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @shot_bp.route("/rename", methods=["POST"])
 def rename_shot():
     try:

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -429,6 +429,31 @@ class ShotManager:
                     continue
         return sorted(set(versions))
 
+    def get_asset_versions(self, shot_name, asset_type):
+        """Return a sorted list of available asset versions."""
+        validate_shot_name(shot_name)
+
+        if asset_type == 'image':
+            base_dir = self.wip_dir / shot_name / 'images'
+            extensions = ALLOWED_IMAGE_EXTENSIONS
+        elif asset_type == 'video':
+            base_dir = self.wip_dir / shot_name / 'videos'
+            extensions = ALLOWED_VIDEO_EXTENSIONS
+        else:
+            raise ValueError('Invalid asset type')
+
+        versions = []
+        if base_dir.exists():
+            for ext in extensions:
+                for f in base_dir.glob(f'{shot_name}_v*{ext}'):
+                    try:
+                        ver_str = f.stem.split('_v')[1]
+                        versions.append(int(ver_str))
+                    except (IndexError, ValueError):
+                        continue
+
+        return sorted(set(versions), reverse=True)
+
     def get_thumbnail_path(self, image_path, shot_name):
         """Return (and create if necessary) the thumbnail for an image."""
         if not image_path:

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -308,16 +308,17 @@
         }
 
 
-        .version-badge {
+        .asset-version-select {
             position: absolute;
             bottom: 4px;
             left: 4px;
+        }
+
+        .asset-version-select .pill-button {
             background: #00c851;
             color: #1a1a1a;
-            padding: 2px 6px;
-            border-radius: 4px;
+            padding: 2px 8px;
             font-size: 11px;
-            font-weight: 500;
         }
 
         .prompt-button {


### PR DESCRIPTION
## Summary
- allow switching asset versions from thumbnail by selecting version
- support listing available asset versions and switching the latest file
- style new asset version pillbox dropdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878e2c67dc832c8368356ad61786a3