### PR TITLE
Style asset thumbnail version dropdown with pill look

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -331,10 +331,14 @@
             left: 4px;
             background: #00c851;
             color: #1a1a1a;
-            padding: 2px 6px;
-            border-radius: 4px;
+            padding: 2px 10px;
+            border-radius: 999px;
             font-size: 11px;
-            font-weight: 500;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            cursor: pointer;
         }
 
         .prompt-button {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -278,7 +278,7 @@
                                 style="${thumbnailStyle}"
                                 onclick="revealFile('${file.file}')"></div>
 
-                            <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
+                              <div class="version-badge">v${String(file.version).padStart(3, '0')} &#9662;</div>
                             <button class="prompt-button"
                                     title="View and edit prompt"
                                     data-shot="${shot.name}"
@@ -318,7 +318,7 @@
                         <div class="drop-zone lipsync-drop" ondragover="handleDragOver(event, '${part}')" ondrop="handleDrop(event, '${shot.name}', '${part}')" ondragleave="handleDragLeave(event)">
                             <div class="file-preview lipsync-preview">
                                 <div class="preview-thumbnail lipsync-thumbnail" data-label="${label}" style="${thumbnailStyle}" onclick="revealFile('${file.file}')"></div>
-                                <div class="version-badge">v${String(file.version).padStart(3, '0')}</div>
+                                <div class="version-badge">v${String(file.version).padStart(3, '0')} &#9662;</div>
                                 <button class="prompt-button" title="View and edit prompt"
                                         data-shot="${shot.name}"
                                         data-type="${part}"


### PR DESCRIPTION
## Summary
- restyle asset thumbnail version badge to a rounded pill while keeping its green brand color
- add dropdown arrow indicator to version badge markup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20ed96e04832c892171c019791c14