### PR TITLE
Add asset version selection to thumbnails

### DIFF
--- a/app/routes/shot_routes.py
+++ b/app/routes/shot_routes.py
@@ -156,6 +156,53 @@ def get_prompt_versions():
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
 
+@shot_bp.route("/versions")
+def get_asset_versions():
+    try:
+        shot_name = request.args.get("shot_name")
+        asset_type = request.args.get("asset_type")
+        if not shot_name or not asset_type:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        shot_manager = get_shot_manager(project["path"])
+        versions = shot_manager.get_asset_versions(shot_name, asset_type)
+        return jsonify({"success": True, "data": versions})
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+@shot_bp.route("/use-version", methods=["POST"])
+def use_version():
+    try:
+        data = request.get_json()
+        shot_name = data.get("shot_name")
+        asset_type = data.get("asset_type")
+        version = data.get("version")
+
+        if not shot_name or not asset_type or version is None:
+            return jsonify({"success": False, "error": "Missing parameters"}), 400
+
+        project_manager = current_app.config['PROJECT_MANAGER']
+        project = project_manager.get_current_project()
+        if not project:
+            return jsonify({"success": False, "error": "No current project"}), 400
+
+        file_handler = FileHandler(project['path'])
+        result = file_handler.use_version(shot_name, asset_type, int(version))
+
+        shot_manager = get_shot_manager(project["path"])
+        prompt = shot_manager.load_prompt(shot_name, asset_type, int(version))
+        result['prompt'] = prompt
+        return jsonify({"success": True, "data": result})
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @shot_bp.route("/rename", methods=["POST"])
 def rename_shot():
     try:

--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -427,6 +427,35 @@ class ShotManager:
                     continue
         return sorted(set(versions))
 
+    def get_asset_versions(self, shot_name, asset_type):
+        """Return a sorted list of available WIP versions for an asset."""
+        validate_shot_name(shot_name)
+        shot_dir = self.wip_dir / shot_name
+        if asset_type == 'image':
+            base_dir = shot_dir / 'images'
+            base = shot_name
+            exts = ALLOWED_IMAGE_EXTENSIONS
+        elif asset_type == 'video':
+            base_dir = shot_dir / 'videos'
+            base = shot_name
+            exts = ALLOWED_VIDEO_EXTENSIONS
+        elif asset_type in {'driver', 'target', 'result'}:
+            base_dir = shot_dir / 'lipsync'
+            base = f'{shot_name}_{asset_type}'
+            exts = ALLOWED_VIDEO_EXTENSIONS
+        else:
+            raise ValueError('Invalid asset type')
+
+        versions = []
+        if base_dir.exists():
+            for ext in exts:
+                for f in base_dir.glob(f'{base}_v*{ext}'):
+                    try:
+                        versions.append(int(f.stem.split('_v')[1]))
+                    except (IndexError, ValueError):
+                        continue
+        return sorted(set(versions))
+
     def get_thumbnail_path(self, image_path, shot_name):
         """Return (and create if necessary) the thumbnail for an image."""
         if not image_path:

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -581,6 +581,12 @@
             display: block;
         }
 
+        .version-dropdown {
+            top: auto;
+            left: 4px;
+            bottom: 24px;
+        }
+
         .dropdown-item {
             padding: 5px 10px;
             cursor: pointer;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -99,6 +99,21 @@
         </div>
     </div>
 
+    <!-- Version Replace Modal -->
+    <div id="version-confirm-modal" class="modal">
+        <div class="modal-content">
+            <p id="version-confirm-text"></p>
+            <label style="display: flex; align-items: center; gap: 6px; margin: 10px 0;">
+                <input type="checkbox" id="version-confirm-dont-ask" />
+                <span>Don't ask me again.</span>
+            </label>
+            <div class="modal-buttons">
+                <button class="dark-button" onclick="confirmVersionReplace()">OK</button>
+                <button class="dark-button" onclick="cancelVersionReplace()">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <footer class='app-footer'>
         Created by <a href="https://albertbozesan.com/">Albert Bozesan</a> with ChatGPT Codex
     </footer>


### PR DESCRIPTION
## Summary
- add backend endpoints to list and switch asset versions
- allow users to select previous WIP versions from thumbnail version pillbox
- confirm version replacement with optional "Don't ask me again" dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2106d4368832cad236b446ebdebda