### PR TITLE
Refresh version dropdown when asset versions change

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -431,7 +431,14 @@
 
                 if (result.success) {
                     showNotification(`${file.name} uploaded successfully!`);
-                    loadShots(`shot-row-${shotName}`); // Refresh and keep scroll
+                    await loadShots(`shot-row-${shotName}`); // Refresh and keep scroll
+                    const badge = document.querySelector(`.version-badge[data-shot="${shotName}"][data-type="${fileType}"]`);
+                    if (badge && badge.nextElementSibling) {
+                        const menu = badge.nextElementSibling;
+                        delete menu.dataset.loaded;
+                        await toggleAssetVersionDropdown(badge);
+                        menu.classList.remove('show');
+                    }
                 } else {
                     showNotification(result.error || 'Upload failed', 'error');
                 }
@@ -862,6 +869,9 @@ async function selectAssetVersion(badge, version) {
             }
             preview.setAttribute('onclick', `revealFile('${result.data.file}')`);
         }
+        delete menu.dataset.loaded;
+        await toggleAssetVersionDropdown(badge);
+        menu.classList.remove('show');
     } catch (e) {
         console.error('Failed to switch version:', e);
         showNotification('Failed to switch version', 'error');


### PR DESCRIPTION
## Summary
- After uploading a new asset version, clear the cached dropdown list and repopulate it so new versions appear immediately
- When switching to a different asset version, reset and reload the version dropdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a237c57f64832c984c97b3c5753917