### PR TITLE
Handle extra tokens in asset version filenames

### DIFF
--- a/app/services/shot_manager.py
+++ b/app/services/shot_manager.py
@@ -448,12 +448,18 @@ class ShotManager:
 
         versions = []
         if base_dir.exists():
-            for ext in exts:
-                for f in base_dir.glob(f'{base}_v*{ext}'):
-                    try:
-                        versions.append(int(f.stem.split('_v')[1]))
-                    except (IndexError, ValueError):
-                        continue
+            base_lower = base.lower()
+            for f in base_dir.iterdir():
+                if not f.is_file() or f.suffix.lower() not in exts:
+                    continue
+                name = f.stem.lower()
+                if not name.startswith(f"{base_lower}_v"):
+                    continue
+                try:
+                    ver = name.split("_v", 1)[1].split("_", 1)[0]
+                    versions.append(int(ver))
+                except (IndexError, ValueError):
+                    continue
         return sorted(set(versions))
 
     def get_thumbnail_path(self, image_path, shot_name):

--- a/tests/test_asset_versions.py
+++ b/tests/test_asset_versions.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.services.shot_manager import ShotManager
+
+
+def test_get_asset_versions_with_extra_tokens(tmp_path):
+    project_path = tmp_path
+    image_dir = project_path / 'shots' / 'wip' / 'SH001' / 'images'
+    image_dir.mkdir(parents=True)
+    (image_dir / 'SH001_v001_extra.png').write_text('x')
+    (image_dir / 'SH001_v002.PNG').write_text('x')
+    sm = ShotManager(project_path)
+    assert sm.get_asset_versions('SH001', 'image') == [1, 2]


### PR DESCRIPTION
## Summary
- Improve asset version parsing to ignore extra filename tokens and case differences in extensions
- Add test verifying detection of `_v001_extra.png` and uppercase extensions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a238f8ac7c832cb10934888dc1a433