### PR TITLE
Sanitize shot names and add tests

### DIFF
--- a/tests/test_shot_name_sanitization.py
+++ b/tests/test_shot_name_sanitization.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.services.shot_manager import ShotManager, validate_shot_name
+
+
+def test_validate_shot_name_uppercases_lowercase():
+    assert validate_shot_name("sh001") == "SH001"
+
+
+def test_validate_shot_name_trims_whitespace():
+    assert validate_shot_name("  sh003  ") == "SH003"
+
+
+def test_create_shot_structure_trims_whitespace(tmp_path):
+    sm = ShotManager(tmp_path)
+    sm.create_shot_structure("  sh002  ")
+    assert (tmp_path / "shots" / "wip" / "SH002").exists()


### PR DESCRIPTION
## Summary
- sanitize shot names by trimming whitespace and uppercasing before validation
- validate shot names case-insensitively and propagate sanitized values throughout `ShotManager`
- add unit tests covering lowercase and whitespace-trimmed shot names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23bd58668832c839ad09020c523cb