### PR TITLE
Add Tkinter UI and story database support

### DIFF
--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -15,3 +15,6 @@ THUMBNAIL_CACHE_DIR = BASE_DIR / "static" / "thumbnails"
 
 # Default thumbnail resolution (width, height)
 THUMBNAIL_SIZE = (240, 180)
+
+# SQLite database used for storing stories and their episodes
+STORIES_DB_PATH = BASE_DIR / "stories.db"

--- a/app/services/story_manager.py
+++ b/app/services/story_manager.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sqlite3
+from typing import List
+from datetime import datetime
+
+from app.config.constants import STORIES_DB_PATH
+
+
+@dataclass
+class Episode:
+    """Represents a single episode/chapter of a story."""
+
+    title: str
+    content: str
+    order: int
+
+
+class StoryManager:
+    """Handle storage of stories and their episodes in SQLite."""
+
+    def __init__(self, db_path: Path | str = STORIES_DB_PATH):
+        self.db_path = Path(db_path)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # database helpers
+    def _connect(self):
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS stories (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    author TEXT,
+                    description TEXT,
+                    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS episodes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    story_id INTEGER NOT NULL,
+                    ord INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    FOREIGN KEY(story_id) REFERENCES stories(id)
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def add_story(self, title: str, author: str, description: str, file_path: Path | str):
+        """Add a story and parse the provided markdown text file into episodes."""
+        text = Path(file_path).read_text(encoding="utf-8")
+        episodes = parse_markdown_episodes(text)
+
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO stories (title, author, description, created) VALUES (?, ?, ?, ?)",
+                (title, author, description, datetime.now()),
+            )
+            story_id = cur.lastrowid
+
+            for ep in episodes:
+                cur.execute(
+                    "INSERT INTO episodes (story_id, ord, title, content) VALUES (?, ?, ?, ?)",
+                    (story_id, ep.order, ep.title, ep.content),
+                )
+            conn.commit()
+        return story_id
+
+
+# ----------------------------------------------------------------------
+def parse_markdown_episodes(text: str) -> List[Episode]:
+    """Parse markdown text into a list of episodes.
+
+    Chapters are identified by lines beginning with a single ``#``. The text
+    following each heading becomes the episode content.
+    """
+    pattern = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    episodes: List[Episode] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        content = text[start:end].strip()
+        title = match.group(1).strip()
+        episodes.append(Episode(title=title, content=content, order=index))
+    return episodes
+

--- a/story_ui.py
+++ b/story_ui.py
@@ -1,0 +1,74 @@
+"""Simple Tkinter UI for adding stories to the database."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+from app.services.story_manager import StoryManager
+
+
+manager = StoryManager()
+
+
+def browse_file():
+    path = filedialog.askopenfilename(filetypes=[("Text files", "*.txt")])
+    if path:
+        file_var.set(path)
+
+
+def submit():
+    title = title_entry.get().strip()
+    author = author_entry.get().strip()
+    description = desc_text.get("1.0", tk.END).strip()
+    file_path = file_var.get().strip()
+
+    if not title or not file_path:
+        messagebox.showerror("Error", "Title and book file are required.")
+        return
+
+    try:
+        manager.add_story(title, author, description, file_path)
+    except Exception as exc:  # pragma: no cover - GUI error display
+        messagebox.showerror("Error", str(exc))
+        return
+
+    messagebox.showinfo("Success", "Story added to database.")
+    title_entry.delete(0, tk.END)
+    author_entry.delete(0, tk.END)
+    desc_text.delete("1.0", tk.END)
+    file_var.set("")
+
+
+root = tk.Tk()
+root.title("Add Story")
+
+# Title field
+tk.Label(root, text="Title:").grid(row=0, column=0, sticky="e")
+title_entry = tk.Entry(root, width=50)
+title_entry.grid(row=0, column=1, padx=5, pady=5)
+
+# Author field
+tk.Label(root, text="Author:").grid(row=1, column=0, sticky="e")
+author_entry = tk.Entry(root, width=50)
+author_entry.grid(row=1, column=1, padx=5, pady=5)
+
+# Description field
+tk.Label(root, text="Description:").grid(row=2, column=0, sticky="ne")
+desc_text = tk.Text(root, width=50, height=5)
+desc_text.grid(row=2, column=1, padx=5, pady=5)
+
+# File path field
+tk.Label(root, text="Book File:").grid(row=3, column=0, sticky="e")
+file_var = tk.StringVar()
+file_entry = tk.Entry(root, textvariable=file_var, width=40)
+file_entry.grid(row=3, column=1, padx=5, pady=5, sticky="w")
+browse_btn = tk.Button(root, text="Browse", command=browse_file)
+browse_btn.grid(row=3, column=2, padx=5, pady=5)
+
+# Submit button
+submit_btn = tk.Button(root, text="Submit", command=submit)
+submit_btn.grid(row=4, column=1, pady=10)
+
+root.mainloop()
+


### PR DESCRIPTION
## Summary
- add SQLite path constant for storing stories
- implement StoryManager to parse markdown chapters into episodes and save to database
- provide Tkinter UI to enter story metadata and import text files

## Testing
- `python -m py_compile app/services/story_manager.py story_ui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73f0247fc832cb03d07c139115017